### PR TITLE
More modular grammer

### DIFF
--- a/grammars/cisco.cson
+++ b/grammars/cisco.cson
@@ -594,11 +594,14 @@
         'end': '$'
         'patterns': [
           {
-            'match': '\\s(forward-protocol|bootp|lookup|multicast|hardware-switching|replication-mode|icmp|rate-limit|unreachable|authentication|timeout-policy|idle|life|local|pool|dhcp|excluded-address|use|connected|pim|rp-address|multicast-routing|source-route|vrf|cef|name-server|domain|name|telnet|source-interface|standard|extended|http|server|secure-server|route|subnet-zero|classless)(?=\\s)'
+            'match': '\\s(forward-protocol|bootp|lookup|multicast|hardware-switching|replication-mode|icmp|rate-limit|unreachable|authentication|timeout-policy|idle|life|local|pool|dhcp|excluded-address|use|connected|pim|rp-address|multicast-routing|source-route|vrf|cef|name-server|domain|name|telnet|source-interface|standard|extended|http|server|secure-server|route|subnet-zero|classless|route|global)(?=\\s)'
             'name': 'keyword.other.ip'
           }
           {
             'include': '#ip_address'
+          }
+          {
+            'include': '#subnet_mask'
           }
           {
             'include': '#interface_types'
@@ -1053,6 +1056,9 @@
           }
           {
             'include': '#ip_address'
+          }
+          {
+            'include': '#subnet_mask'
           }
           {
             'include': '#disable'


### PR DESCRIPTION
I built this grammer last year for textmate. I converted it to atom format and added in some bits from the existing grammer. It contains a bunch more of the modern Cisco configurations but does not contain a lot of the old configurations found in your grammer such as Appletalk, x.25, apollo but these are rarely encountered these days. Please consider my pull request. I will continue to add more grammer elements it is far from complete but does currently get about 80-90% of most configurations. 
