### PR TITLE
Added VTP modes and options

### DIFF
--- a/grammars/cisco.cson
+++ b/grammars/cisco.cson
@@ -1817,7 +1817,7 @@
         'end': '$'
         'patterns': [
           {
-            'match': '\\s(mode|transparent|server)(?=\\s)'
+            'match': '\\s(mode|transparent|server|client|off|password|pruning|version|domain)(?=\\s)'
             'name': 'keyword.other.logging'
           }
         ]


### PR DESCRIPTION
Added the two other VTP modes, and some other VTP configurables.

See this Cisco page for more details about VTP and its modes: https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst3560/software/release/12-2_52_se/configuration/guide/3560scg/swvtp.html#wp1310010